### PR TITLE
Add Automated Verifications for Administrator Interactions

### DIFF
--- a/migrations/deploy/README.md
+++ b/migrations/deploy/README.md
@@ -2,7 +2,9 @@
 
 This deploys a Flashbake Registry contract.
 
-Usage:
+## Usage
+
+Pre-reqs:
 ```
 # Install typescipt
 $ npm i -g typescript
@@ -10,6 +12,12 @@ $ npm i -g typescript
 # Install deps
 $ npm i
 
+# Get SmartPy
+sh <(curl -s https://smartpy.io/releases/20210929-ec4c2020b1e18201600a732d442303c6830f8995/cli/install.sh )
+```
+
+Prepare a deploy
+```
 # Remove any stale artifacts
 rm -rf src/config.ts deploy-data.json
 
@@ -22,7 +30,18 @@ $ cp src/config.testnet.ts src/config.ts
 
 # Run migration
 $ ts-node src/flows/migrate.ts
+```
 
+Validations (testnet and mainnet):
+```
 # Validate storage applied as expected
 $ ts-node src/verifications/verify-storage.ts
+```
+
+Validations (testnet only):
+```
+# Validate that the administrator can admin the registry.
+# NOTE: this step will change bondAmount so it is destructive.
+# NOTE: this step will not work on mainnet, since the contract will require many signatures.
+$ ts-node src/verifications/verify-administrator.ts
 ```

--- a/migrations/deploy/src/verifications/verify-administrator.ts
+++ b/migrations/deploy/src/verifications/verify-administrator.ts
@@ -1,0 +1,40 @@
+import {
+  ContractOriginationResult,
+  callThroughMultisig,
+  fetchFromCache,
+  getTezos,
+  validateStorageValue,
+} from "@hover-labs/tezos-utils"
+import CACHE_KEYS from '../cache-keys'
+import { NETWORK_CONFIG } from '../config'
+
+const main = async () => {
+  console.log("Validating that the administrator can control the registry")
+  console.log("")
+
+  // Load deployed contracts
+  const tezos = await getTezos(NETWORK_CONFIG)
+  const multisigContractAddress = (await fetchFromCache(CACHE_KEYS.MULTISIG_DEPLOY) as ContractOriginationResult).contractAddress
+  const registryContractAddress = (await fetchFromCache(CACHE_KEYS.REGISTRY_DEPLOY) as ContractOriginationResult).contractAddress
+
+  // Call through the multisig to set the new bond amount.
+  const newBondAmount = "123456789"
+  await callThroughMultisig(
+    NETWORK_CONFIG,
+    multisigContractAddress,
+    registryContractAddress,
+    'setBondAmount',
+    `sp.mutez(${newBondAmount})`,
+    tezos
+  )
+
+  // Verify the bond amount changed
+  await validateStorageValue(registryContractAddress, 'bondAmount', newBondAmount, tezos)
+
+  console.log("   / passed")
+  console.log("")
+
+  console.log("All tests pass!")
+  console.log("")
+}
+main()

--- a/migrations/deploy/src/verifications/verify-storage.ts
+++ b/migrations/deploy/src/verifications/verify-storage.ts
@@ -29,7 +29,8 @@ const main = async () => {
   await validateStorageValue(multisigContractAddress, 'timelockSeconds', MIGRATION_CONFIG.timelockSeconds, tezos)
 
   console.log("   / passed")
-
+  console.log("")
+  
   // Registry
   // 1) administratorAddress should be the multisig
   // 2) bondAmount should match the MIGRATION_CONFIG
@@ -44,6 +45,7 @@ const main = async () => {
   await validateMetadata(registryContractAddress, tezos)
 
   console.log("   / passed")
+  console.log("")
 
   console.log("All tests pass!")
   console.log("")


### PR DESCRIPTION
Add a verification (which only works on testnet) to prove that the administrator can modify the bond amount.

Update docs accordingly. 