### PR TITLE
Remove TODOs for Codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,11 @@
 
 This repository contains an on-chain registry for Flashbake Bakers.
 
-Project structure / TODOs:
+Project structure:
 - `.github/`: Continuous integration configuration
-- `migrations/`: TODO
-- `multisig-timelock/`: TODO
+- `migrations/`: Automated scripts to deploy, upgrade and verify contract interactions
+- `multisig-timelock/`: Submodule for the timelocked multisig contract
 - `smart_contracts/`: Smart contract code
-
-Additional TODOs:
-- Fix contract metadata fields
 
 ## Introduction
 

--- a/migrations/deploy/src/config.mainnet.ts
+++ b/migrations/deploy/src/config.mainnet.ts
@@ -11,7 +11,6 @@ export const NETWORK_CONFIG: NetworkConfig = {
   operationDelaySecs: 45,
 }
 
-// TODO(keefertaylor): Configure this migration.
 export const MIGRATION_CONFIG = {
   // Initial Bond Amount
   bondAmountMutez: new BigNumber(50).times(new BigNumber(CONSTANTS.XTZ_MANTISSA)), // 50 XTZ


### PR DESCRIPTION
- Remove resolved TODOs
- Resolve documentation TODOs by writing the documentation
- Move remaining TODOs to GitHub issues for visibility (see #5, #7)